### PR TITLE
Add Exams/Timer navigation with study timer UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/user-event": "^13.5.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-router-dom": "^6.30.1",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
       }
@@ -3084,6 +3085,15 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -13914,6 +13924,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-router-dom": "^6.30.1",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -1,24 +1,18 @@
-import logo from './logo.svg';
 import './App.css';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import Navbar from './components/Navbar';
+import Exams from './components/Exams';
+import Timer from './components/Timer';
 
 function App() {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
+    <Router>
+      <Navbar />
+      <Routes>
+        <Route path="/" element={<Exams />} />
+        <Route path="/timer" element={<Timer />} />
+      </Routes>
+    </Router>
   );
 }
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders Timer link', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
+  const linkElement = screen.getByRole('link', { name: /Timer/i });
   expect(linkElement).toBeInTheDocument();
 });

--- a/src/components/Exams.js
+++ b/src/components/Exams.js
@@ -1,0 +1,10 @@
+function Exams() {
+  return (
+    <div className="exams">
+      <h2>Exams</h2>
+      <p>This is the Exams page.</p>
+    </div>
+  );
+}
+
+export default Exams;

--- a/src/components/Navbar.css
+++ b/src/components/Navbar.css
@@ -1,0 +1,18 @@
+.navbar {
+  background-color: #282c34;
+  padding: 10px;
+}
+
+.navbar ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 1rem;
+}
+
+.navbar a {
+  color: white;
+  text-decoration: none;
+  font-weight: bold;
+}

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,0 +1,15 @@
+import { Link } from 'react-router-dom';
+import './Navbar.css';
+
+function Navbar() {
+  return (
+    <nav className="navbar">
+      <ul>
+        <li><Link to="/">Exams</Link></li>
+        <li><Link to="/timer">Timer</Link></li>
+      </ul>
+    </nav>
+  );
+}
+
+export default Navbar;

--- a/src/components/Timer.css
+++ b/src/components/Timer.css
@@ -1,0 +1,15 @@
+.timer-container {
+  text-align: center;
+  padding: 2rem;
+}
+
+.display {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+}
+
+.controls button {
+  margin: 0 0.5rem;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+}

--- a/src/components/Timer.js
+++ b/src/components/Timer.js
@@ -1,0 +1,44 @@
+import { useState, useEffect } from 'react';
+import './Timer.css';
+
+function Timer() {
+  const [seconds, setSeconds] = useState(0);
+  const [isRunning, setIsRunning] = useState(false);
+
+  useEffect(() => {
+    let interval;
+    if (isRunning) {
+      interval = setInterval(() => {
+        setSeconds(prev => prev + 1);
+      }, 1000);
+    }
+    return () => clearInterval(interval);
+  }, [isRunning]);
+
+  const start = () => setIsRunning(true);
+  const stop = () => setIsRunning(false);
+  const reset = () => {
+    setSeconds(0);
+    setIsRunning(false);
+  };
+
+  const formatTime = (s) => {
+    const mins = String(Math.floor(s / 60)).padStart(2, '0');
+    const secs = String(s % 60).padStart(2, '0');
+    return `${mins}:${secs}`;
+  };
+
+  return (
+    <div className="timer-container">
+      <h2>Study Timer</h2>
+      <div className="display">{formatTime(seconds)}</div>
+      <div className="controls">
+        <button onClick={start} disabled={isRunning}>Start</button>
+        <button onClick={stop} disabled={!isRunning}>Stop</button>
+        <button onClick={reset}>Reset</button>
+      </div>
+    </div>
+  );
+}
+
+export default Timer;


### PR DESCRIPTION
## Summary
- set up React Router
- add a Navbar with links to **Exams** and **Timer**
- create `Timer` component with basic start/stop/reset logic
- add simple `Exams` placeholder page
- update tests for new navigation

## Testing
- `npm test -- -u --watchAll=false`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840115161948321b4aaf5591d606718